### PR TITLE
[Memory Hackathon] Mbed TLS write functions should be behind a feature flag

### DIFF
--- a/mbed-client-pal/Configs/mbedTLS/mbedTLSConfig_mbedOS.h
+++ b/mbed-client-pal/Configs/mbedTLS/mbedTLSConfig_mbedOS.h
@@ -16,7 +16,7 @@
 #define PAL_MBEDTLS_USER_CONFIG_H
 
 
-/*! All of the following definitions are mandatory requirements for correct 
+/*! All of the following definitions are mandatory requirements for correct
 *   fucntionality of PAL TLS and Crypto components.
 *   Please do not disable them.
 */
@@ -169,14 +169,6 @@
 #ifndef MBEDTLS_X509_CSR_PARSE_C
     #define MBEDTLS_X509_CSR_PARSE_C
 #endif //MBEDTLS_X509_CSR_PARSE_C
-
-#ifndef MBEDTLS_X509_CREATE_C
-    #define MBEDTLS_X509_CREATE_C
-#endif //MBEDTLS_X509_CREATE_C
-
-#ifndef MBEDTLS_X509_CSR_WRITE_C
-    #define MBEDTLS_X509_CSR_WRITE_C
-#endif //MBEDTLS_X509_CSR_WRITE_C
 
 #ifndef MBEDTLS_CTR_DRBG_MAX_REQUEST
     #define MBEDTLS_CTR_DRBG_MAX_REQUEST 2048

--- a/mbed-client-pal/Configs/mbedTLS/mbedTLSConfig_mbedOS.h
+++ b/mbed-client-pal/Configs/mbedTLS/mbedTLSConfig_mbedOS.h
@@ -82,10 +82,6 @@
     #define MBEDTLS_ASN1_PARSE_C
 #endif //MBEDTLS_ASN1_PARSE_C
 
-#ifndef MBEDTLS_ASN1_WRITE_C
-    #define MBEDTLS_ASN1_WRITE_C
-#endif //MBEDTLS_ASN1_WRITE_C
-
 #ifndef MBEDTLS_BIGNUM_C
     #define MBEDTLS_BIGNUM_C
 #endif //MBEDTLS_BIGNUM_C
@@ -121,6 +117,10 @@
 #ifndef MBEDTLS_PK_PARSE_C
     #define MBEDTLS_PK_PARSE_C
 #endif //MBEDTLS_PK_PARSE_C
+
+#ifdef MBEDTLS_PK_WRITE_C
+    #undef MBEDTLS_PK_WRITE_C
+#endif
 
 #ifndef MBEDTLS_SHA256_C
     #define MBEDTLS_SHA256_C

--- a/mbed-client-pal/Source/PAL-Impl/Modules/Crypto/pal_Crypto.c
+++ b/mbed-client-pal/Source/PAL-Impl/Modules/Crypto/pal_Crypto.c
@@ -434,20 +434,28 @@ palStatus_t pal_parseECPublicKeyFromDER(const unsigned char* pubDERKey, size_t k
 
 palStatus_t pal_writePrivateKeyToDer(palECKeyHandle_t key, unsigned char* derBuffer, size_t bufferSize, size_t* actualSize)
 {
+#if (PAL_ENABLE_X509_WRITE == 1)
     palStatus_t status = PAL_SUCCESS;
     PAL_VALIDATE_ARGUMENTS((NULLPTR == key || NULL == derBuffer || NULL == actualSize))
 
     status = pal_plat_writePrivateKeyToDer(key, derBuffer, bufferSize, actualSize);
     return status;
+#else
+    return PAL_ERR_NOT_SUPPORTED;
+#endif
 }
 
 palStatus_t pal_writePublicKeyToDer(palECKeyHandle_t key, unsigned char* derBuffer, size_t bufferSize, size_t* actualSize)
 {
+#if (PAL_ENABLE_X509_WRITE == 1)
     palStatus_t status = PAL_SUCCESS;
     PAL_VALIDATE_ARGUMENTS((NULLPTR == key || NULL == derBuffer || NULL == actualSize))
 
     status = pal_plat_writePublicKeyToDer(key, derBuffer, bufferSize, actualSize);
     return status;
+#else
+    return PAL_ERR_NOT_SUPPORTED;
+#endif
 }
 palStatus_t pal_ECGroupInitAndLoad(palCurveHandle_t* grp, palGroupIndex_t index)
 {

--- a/mbed-client-pal/Source/PAL-Impl/Modules/Crypto/pal_Crypto.c
+++ b/mbed-client-pal/Source/PAL-Impl/Modules/Crypto/pal_Crypto.c
@@ -220,12 +220,12 @@ palStatus_t pal_verifySignature(palX509Handle_t x509, palMDType_t mdType, const 
 	return PAL_ERR_NOT_SUPPORTED;
 #endif
 }
- 
+
 palStatus_t pal_ASN1GetTag(unsigned char **position, const unsigned char *end, size_t *len, uint8_t tag )
 {
     palStatus_t status = PAL_SUCCESS;
     PAL_VALIDATE_ARGUMENTS((NULL == position || NULL == end || NULL == len))
-    
+
     status = pal_plat_ASN1GetTag(position, end, len, tag);
     return status;
 }
@@ -257,9 +257,9 @@ palStatus_t pal_CCMSetKey(palCCMHandle_t ctx, const unsigned char *key, uint32_t
     return status;
 }
 
-palStatus_t pal_CCMDecrypt(palCCMHandle_t ctx, unsigned char* input, size_t inLen, 
-							unsigned char* iv, size_t ivLen, unsigned char* add, 
-							size_t addLen, unsigned char* tag, size_t tagLen, 
+palStatus_t pal_CCMDecrypt(palCCMHandle_t ctx, unsigned char* input, size_t inLen,
+							unsigned char* iv, size_t ivLen, unsigned char* add,
+							size_t addLen, unsigned char* tag, size_t tagLen,
 							unsigned char* output)
 {
     palStatus_t status = PAL_SUCCESS;
@@ -269,9 +269,9 @@ palStatus_t pal_CCMDecrypt(palCCMHandle_t ctx, unsigned char* input, size_t inLe
     return status;
 }
 
-palStatus_t pal_CCMEncrypt(palCCMHandle_t ctx, unsigned char* input, 
-							size_t inLen, unsigned char* iv, size_t ivLen, 
-							unsigned char* add, size_t addLen, unsigned char* output, 
+palStatus_t pal_CCMEncrypt(palCCMHandle_t ctx, unsigned char* input,
+							size_t inLen, unsigned char* iv, size_t ivLen,
+							unsigned char* add, size_t addLen, unsigned char* output,
 							unsigned char* tag, size_t tagLen)
 {
     palStatus_t status = PAL_SUCCESS;
@@ -330,10 +330,10 @@ palStatus_t pal_cipherCMAC(const unsigned char *key, size_t keyLenInBits, const 
 	PAL_VALIDATE_ARGUMENTS((NULL == key || NULL == input || NULL == output))
 #if PAL_CMAC_SUPPORT
     status = pal_plat_cipherCMAC(key, keyLenInBits, input, inputLenInBytes, output);
-#else   // no CMAC support		
+#else   // no CMAC support
     status = PAL_ERR_NOT_SUPPORTED;
-    PAL_LOG(ERR, "CMAC support in PAL is disabled");		
-#endif 
+    PAL_LOG(ERR, "CMAC support in PAL is disabled");
+#endif
     return status;
 }
 
@@ -343,9 +343,9 @@ palStatus_t pal_CMACStart(palCMACHandle_t *ctx, const unsigned char *key, size_t
 	PAL_VALIDATE_ARGUMENTS((NULLPTR == ctx || NULL == key))
 #if PAL_CMAC_SUPPORT
     status = pal_plat_CMACStart(ctx, key, keyLenBits, cipherID);
-#else   // no CMAC support		
+#else   // no CMAC support
     status = PAL_ERR_NOT_SUPPORTED;
-    PAL_LOG(ERR, "CMAC support in PAL is disabled");		
+    PAL_LOG(ERR, "CMAC support in PAL is disabled");
 #endif
     return status;
 }
@@ -357,10 +357,10 @@ palStatus_t pal_CMACUpdate(palCMACHandle_t ctx, const unsigned char *input, size
     PAL_VALIDATE_ARGUMENTS((NULLPTR == ctx || NULL == input))
 
     status = pal_plat_CMACUpdate(ctx, input, inLen);
-#else   // no CMAC support		
-    palStatus_t status = PAL_ERR_NOT_SUPPORTED;		
-    PAL_LOG(ERR, "CMAC support in PAL is disabled");		
-#endif 
+#else   // no CMAC support
+    palStatus_t status = PAL_ERR_NOT_SUPPORTED;
+    PAL_LOG(ERR, "CMAC support in PAL is disabled");
+#endif
     return status;
 }
 
@@ -371,10 +371,10 @@ palStatus_t pal_CMACFinish(palCMACHandle_t *ctx, unsigned char *output, size_t* 
     PAL_VALIDATE_ARGUMENTS(NULLPTR == ctx || NULLPTR == *ctx || NULL == output || NULL == outLen)
 
     status = pal_plat_CMACFinish(ctx, output, outLen);
-#else   // no CMAC support		
-    palStatus_t status = PAL_ERR_NOT_SUPPORTED;		
-    PAL_LOG(ERR, "CMAC support in PAL is disabled");		
-#endif 
+#else   // no CMAC support
+    palStatus_t status = PAL_ERR_NOT_SUPPORTED;
+    PAL_LOG(ERR, "CMAC support in PAL is disabled");
+#endif
     return status;
 }
 
@@ -487,7 +487,7 @@ palStatus_t pal_ECKeyGetCurve(palECKeyHandle_t key, palGroupIndex_t* grpID)
 
 palStatus_t pal_x509CSRInit(palx509CSRHandle_t *x509CSR)
 {
-#if (PAL_ENABLE_X509 == 1)
+#if (PAL_ENABLE_X509_WRITE == 1)
     palStatus_t status = PAL_SUCCESS;
     PAL_VALIDATE_ARGUMENTS((NULL == x509CSR))
 
@@ -500,7 +500,7 @@ palStatus_t pal_x509CSRInit(palx509CSRHandle_t *x509CSR)
 
 palStatus_t pal_x509CSRSetSubject(palx509CSRHandle_t x509CSR, const char* subjectName)
 {
-#if (PAL_ENABLE_X509 == 1)
+#if (PAL_ENABLE_X509_WRITE == 1)
     palStatus_t status = PAL_SUCCESS;
     PAL_VALIDATE_ARGUMENTS((NULLPTR == x509CSR || NULL == subjectName))
 
@@ -513,7 +513,7 @@ palStatus_t pal_x509CSRSetSubject(palx509CSRHandle_t x509CSR, const char* subjec
 
 palStatus_t pal_x509CSRSetKey(palx509CSRHandle_t x509CSR, palECKeyHandle_t pubKey, palECKeyHandle_t prvKey)
 {
-#if (PAL_ENABLE_X509 == 1)
+#if (PAL_ENABLE_X509_WRITE == 1)
     palStatus_t status = PAL_SUCCESS;
     PAL_VALIDATE_ARGUMENTS((NULLPTR == x509CSR || NULLPTR == pubKey))
 
@@ -526,7 +526,7 @@ palStatus_t pal_x509CSRSetKey(palx509CSRHandle_t x509CSR, palECKeyHandle_t pubKe
 
 palStatus_t pal_x509CSRSetMD(palx509CSRHandle_t x509CSR, palMDType_t mdType)
 {
-#if (PAL_ENABLE_X509 == 1)
+#if (PAL_ENABLE_X509_WRITE == 1)
     palStatus_t status = PAL_SUCCESS;
     PAL_VALIDATE_ARGUMENTS((NULLPTR == x509CSR))
 
@@ -539,7 +539,7 @@ palStatus_t pal_x509CSRSetMD(palx509CSRHandle_t x509CSR, palMDType_t mdType)
 
 palStatus_t pal_x509CSRSetKeyUsage(palx509CSRHandle_t x509CSR, uint32_t keyUsage)
 {
-#if (PAL_ENABLE_X509 == 1)
+#if (PAL_ENABLE_X509_WRITE == 1)
     palStatus_t status = PAL_SUCCESS;
     PAL_VALIDATE_ARGUMENTS((NULLPTR == x509CSR))
 
@@ -552,7 +552,7 @@ palStatus_t pal_x509CSRSetKeyUsage(palx509CSRHandle_t x509CSR, uint32_t keyUsage
 
 palStatus_t pal_x509CSRSetExtendedKeyUsage(palx509CSRHandle_t x509CSR, uint32_t extKeyUsage)
 {
-#if (PAL_ENABLE_X509 == 1)
+#if (PAL_ENABLE_X509_WRITE == 1)
     palStatus_t status = PAL_SUCCESS;
     PAL_VALIDATE_ARGUMENTS((NULLPTR == x509CSR))
 
@@ -565,7 +565,7 @@ palStatus_t pal_x509CSRSetExtendedKeyUsage(palx509CSRHandle_t x509CSR, uint32_t 
 
 palStatus_t pal_x509CSRSetExtension(palx509CSRHandle_t x509CSR,const char* oid, size_t oidLen, const unsigned char* value, size_t valueLen)
 {
-#if (PAL_ENABLE_X509 == 1)
+#if (PAL_ENABLE_X509_WRITE == 1)
     palStatus_t status = PAL_SUCCESS;
     PAL_VALIDATE_ARGUMENTS((NULLPTR == x509CSR || NULL == oid || NULL == value))
 
@@ -578,7 +578,7 @@ palStatus_t pal_x509CSRSetExtension(palx509CSRHandle_t x509CSR,const char* oid, 
 
 palStatus_t pal_x509CSRWriteDER(palx509CSRHandle_t x509CSR, unsigned char* derBuf, size_t derBufLen, size_t* actualDerLen)
 {
-#if (PAL_ENABLE_X509 == 1)
+#if (PAL_ENABLE_X509_WRITE == 1)
     palStatus_t status = PAL_SUCCESS;
     PAL_VALIDATE_ARGUMENTS((NULLPTR == x509CSR || NULL == derBuf))
 
@@ -591,7 +591,7 @@ palStatus_t pal_x509CSRWriteDER(palx509CSRHandle_t x509CSR, unsigned char* derBu
 
 palStatus_t pal_x509CSRFree(palx509CSRHandle_t *x509CSR)
 {
-#if (PAL_ENABLE_X509 == 1)
+#if (PAL_ENABLE_X509_WRITE == 1)
     palStatus_t status = PAL_SUCCESS;
     PAL_VALIDATE_ARGUMENTS((NULL == x509CSR || NULLPTR == *x509CSR))
 
@@ -602,7 +602,7 @@ palStatus_t pal_x509CSRFree(palx509CSRHandle_t *x509CSR)
 #endif
 }
 
-palStatus_t pal_ECDHComputeKey(const palCurveHandle_t grp, const palECKeyHandle_t peerPublicKey, 
+palStatus_t pal_ECDHComputeKey(const palCurveHandle_t grp, const palECKeyHandle_t peerPublicKey,
                             const palECKeyHandle_t privateKey, palECKeyHandle_t outKey)
 {
     palStatus_t status = PAL_SUCCESS;
@@ -612,22 +612,22 @@ palStatus_t pal_ECDHComputeKey(const palCurveHandle_t grp, const palECKeyHandle_
     return status;
 }
 
-palStatus_t pal_ECDSASign(palCurveHandle_t grp, palMDType_t mdType, palECKeyHandle_t prvKey, unsigned char* dgst, 
+palStatus_t pal_ECDSASign(palCurveHandle_t grp, palMDType_t mdType, palECKeyHandle_t prvKey, unsigned char* dgst,
 							uint32_t dgstLen, unsigned char *sig, size_t *sigLen)
 {
     palStatus_t status = PAL_SUCCESS;
     PAL_VALIDATE_ARGUMENTS((NULLPTR == grp || NULLPTR == prvKey || NULL == dgst || NULL == sig || NULL == sigLen))
-    
+
     status = pal_plat_ECDSASign(grp, mdType, prvKey, dgst, dgstLen, sig, sigLen);
     return status;
 }
 
-palStatus_t pal_ECDSAVerify(palECKeyHandle_t pubKey, unsigned char* dgst, uint32_t dgstLen, 
+palStatus_t pal_ECDSAVerify(palECKeyHandle_t pubKey, unsigned char* dgst, uint32_t dgstLen,
                             unsigned char* sig, size_t sigLen, bool* verified)
 {
     palStatus_t status = PAL_SUCCESS;
     PAL_VALIDATE_ARGUMENTS((NULLPTR == pubKey || NULL == dgst || NULL == sig || NULL == verified))
-    
+
     status = pal_plat_ECDSAVerify(pubKey, dgst, dgstLen, sig, sigLen, verified);
     return status;
 }

--- a/mbed-client-pal/Source/PAL-Impl/Services-API/pal_configuration.h
+++ b/mbed-client-pal/Source/PAL-Impl/Services-API/pal_configuration.h
@@ -104,7 +104,7 @@
     #define PAL_NET_DNS_IP_SUPPORT  0 /* sets the type of IP addresses returned by  pal_getAddressInfo*/
 #elif PAL_SUPPORT_IP_V6 == true
     #define PAL_NET_DNS_IP_SUPPORT  4 /* sets the type of IP addresses returned by  pal_getAddressInfo*/
-#else 
+#else
     #define PAL_NET_DNS_IP_SUPPORT  2 /* sets the type of IP addresses returned by  pal_getAddressInfo*/
 #endif
 
@@ -169,7 +169,7 @@
 
 //! 32 or 48 (depends on the curve) bytes for the X,Y coordinates and 1 for the normalized/non-normalized
 #ifndef PAL_CERT_ID_SIZE
-    #define PAL_CERT_ID_SIZE 33 
+    #define PAL_CERT_ID_SIZE 33
 #endif
 
 
@@ -179,7 +179,11 @@
 
 #ifndef PAL_ENABLE_X509
 	#define PAL_ENABLE_X509 1
-#endif 
+#endif
+
+#ifndef PAL_ENABLE_X509_WRITE
+    #define PAL_ENABLE_X509_WRITE 1
+#endif
 
 //! Define the cipher suites for TLS (only one cipher suite per device available).
 #define PAL_TLS_PSK_WITH_AES_128_CBC_SHA256_SUITE               0x01
@@ -281,7 +285,7 @@
 #endif
 
 /*\brief If flash existed set to 1 else 0, the flash is used for none volatile backup*/
-#ifndef PAL_USE_INTERNAL_FLASH 
+#ifndef PAL_USE_INTERNAL_FLASH
     #define PAL_USE_INTERNAL_FLASH  0
 #endif
 
@@ -289,7 +293,7 @@
     #define PAL_INT_FLASH_NUM_SECTIONS 0
 #endif
 
-#ifndef PAL_USE_HW_ROT 
+#ifndef PAL_USE_HW_ROT
     #define PAL_USE_HW_ROT     1
 #endif
 
@@ -304,7 +308,7 @@
 //! The number of valid priorities limits the number of concurrent running threads.
 #ifndef PAL_MAX_NUMBER_OF_THREADS
     #if PAL_USE_HW_TRNG
-        #define PAL_MAX_NUMBER_OF_THREADS 9    
+        #define PAL_MAX_NUMBER_OF_THREADS 9
     #else
         #define PAL_MAX_NUMBER_OF_THREADS 8
     #endif
@@ -327,7 +331,7 @@
 
 #ifndef PAL_DEVICE_KEY_DERIVATION_BACKWARD_COMPATIBILITY_CALC
     #define PAL_DEVICE_KEY_DERIVATION_BACKWARD_COMPATIBILITY_CALC 0
-#endif    
+#endif
 
 /*\brief  Starting Address for  section 1 Minimum requirement size is 1KB and section must be consecutive sectors*/
 #ifndef PAL_INTERNAL_FLASH_SECTION_1_ADDRESS
@@ -352,7 +356,7 @@
 
 
 
-#if (PAL_SIMULATOR_TEST_ENABLE == 1) 
+#if (PAL_SIMULATOR_TEST_ENABLE == 1)
 
     #undef PAL_SIMULATE_RTOS_REBOOT
     #define PAL_SIMULATE_RTOS_REBOOT 1
@@ -374,7 +378,7 @@
 #if PAL_SIMULATOR_FLASH_OVER_FILE_SYSTEM
 
 
-    #undef PAL_USE_INTERNAL_FLASH 
+    #undef PAL_USE_INTERNAL_FLASH
     #define PAL_USE_INTERNAL_FLASH  1
 
     #undef PAL_INT_FLASH_NUM_SECTIONS
@@ -436,7 +440,7 @@
         #pragma message(VAR_NAME_VALUE(PAL_USE_HW_RTC))
         #pragma message(VAR_NAME_VALUE(PAL_USE_HW_TRNG))
         #pragma message(VAR_NAME_VALUE(PAL_INT_FLASH_NUM_SECTIONS))
-    #error Minimum configuration setting does not meet the requirements     
+    #error Minimum configuration setting does not meet the requirements
 #endif
 
 #if (((PAL_ENABLE_PSK == 1) && (PAL_ENABLE_X509 == 1)) && !(defined(__LINUX__)))

--- a/mbed-client-pal/Source/Port/Reference-Impl/Lib_Specific/mbedTLS/Crypto/pal_plat_Crypto.c
+++ b/mbed-client-pal/Source/Port/Reference-Impl/Lib_Specific/mbedTLS/Crypto/pal_plat_Crypto.c
@@ -1417,6 +1417,7 @@ PAL_PRIVATE void moveDataToBufferStart(unsigned char* buffer, size_t bufferSize,
     }
 }
 
+#if (PAL_ENABLE_X509_WRITE == 1)
 palStatus_t pal_plat_writePrivateKeyToDer(palECKeyHandle_t key, unsigned char* derBuffer, size_t bufferSize, size_t* actualSize)
 {
     palStatus_t status = PAL_SUCCESS;
@@ -1468,6 +1469,7 @@ palStatus_t pal_plat_writePublicKeyToDer(palECKeyHandle_t key, unsigned char* de
 
     return status;
 }
+#endif
 
 palStatus_t pal_plat_ECKeyGenerateKey(palGroupIndex_t grpID, palECKeyHandle_t key)
 {

--- a/mbed-client-pal/Source/Port/Reference-Impl/Lib_Specific/mbedTLS/Crypto/pal_plat_Crypto.c
+++ b/mbed-client-pal/Source/Port/Reference-Impl/Lib_Specific/mbedTLS/Crypto/pal_plat_Crypto.c
@@ -24,7 +24,7 @@
 #include "mbedtls/asn1write.h"
 #include "mbedtls/x509_crt.h"
 #include "mbedtls/x509_csr.h"
-#endif 
+#endif
 #include "mbedtls/ctr_drbg.h"
 #include "mbedtls/sha256.h"
 #include "mbedtls/md.h"
@@ -46,7 +46,7 @@ typedef mbedtls_mpi palMP_t;
 typedef mbedtls_pk_context palECKey_t;
 
 #if (PAL_ENABLE_X509 == 1)
-typedef mbedtls_x509write_csr palx509CSR_t; 
+typedef mbedtls_x509write_csr palx509CSR_t;
 #endif
 
 typedef mbedtls_cipher_context_t palCipherCtx_t;
@@ -126,9 +126,9 @@ palStatus_t pal_plat_freeAes(palAesHandle_t *aes)
 {
     palStatus_t status = PAL_SUCCESS;
     palAes_t* localCtx = NULL;
-    
+
     localCtx = (palAes_t*)*aes;
-    
+
     mbedtls_aes_free(&localCtx->platCtx);
     free(localCtx);
     *aes = NULLPTR;
@@ -155,7 +155,7 @@ palStatus_t pal_plat_setAesKey(palAesHandle_t aes, const unsigned char* key, uin
         status = PAL_ERR_AES_INVALID_KEY_LENGTH;
     }
 
-    return status;    
+    return status;
 }
 
 palStatus_t pal_plat_aesCTR(palAesHandle_t aes, const unsigned char* input, unsigned char* output, size_t inLen, unsigned char iv[16], bool zeroOffset)
@@ -195,9 +195,9 @@ palStatus_t pal_plat_aesECB(palAesHandle_t aes, const unsigned char input[PAL_CR
 }
 
 palStatus_t pal_plat_sha256(const unsigned char* input, size_t inLen, unsigned char* output)
-{    
+{
     mbedtls_sha256(input, inLen, output, 0);
-     
+
     return PAL_SUCCESS;
 }
 #if (PAL_ENABLE_X509 == 1)
@@ -234,12 +234,12 @@ palStatus_t pal_plat_x509CertParse(palX509Handle_t x509, const unsigned char* in
 		{
 			status = PAL_ERR_NOT_SUPPORTED_CURVE;
 		}
-		
+
         else if (-(MBEDTLS_ERR_X509_UNKNOWN_SIG_ALG) == ((-platStatus) & 0xFF80))
         {
             status = PAL_ERR_INVALID_MD_TYPE;
         }
-        
+
         else
         {
             status = PAL_ERR_CERT_PARSING_FAILED;
@@ -272,13 +272,13 @@ PAL_PRIVATE palStatus_t pal_plat_X509GetField(palX509Ctx_t* x509Ctx, const char*
     mbedtls_x509_name *x509Name = &x509Ctx->crt.subject;
 
     fieldNameLength = strlen(fieldName);
-    while( x509Name ) 
+    while( x509Name )
     {
         platStatus = mbedtls_oid_get_attr_short_name(&x509Name->oid, &shortName);
         if (CRYPTO_PLAT_SUCCESS != platStatus)
         {
-            status = PAL_ERR_INVALID_IOD; 
-            break;  
+            status = PAL_ERR_INVALID_IOD;
+            break;
         }
         if (strncmp(shortName, fieldName, fieldNameLength) == 0)
         {
@@ -308,7 +308,7 @@ PAL_PRIVATE bool pal_isLeapYear(uint8_t year)
     else if ((year % 100) != 0)
     {
         result = true;
-    } 
+    }
     else
     {
         result = ((year % 400) == 0);
@@ -316,7 +316,7 @@ PAL_PRIVATE bool pal_isLeapYear(uint8_t year)
     return result;
 }
 
-PAL_PRIVATE palStatus_t pal_timegm( struct tm *tm, uint64_t* outTime) 
+PAL_PRIVATE palStatus_t pal_timegm( struct tm *tm, uint64_t* outTime)
 {
     uint64_t epoc = 0;
     uint8_t palMonthDays[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
@@ -335,10 +335,10 @@ PAL_PRIVATE palStatus_t pal_timegm( struct tm *tm, uint64_t* outTime)
         else
         {
             epoc += 365 * PAL_SECONDS_PER_DAY;
-        }      
+        }
     }
-    
-    for (uint8_t m = 1; m < tm->tm_mon; ++m) 
+
+    for (uint8_t m = 1; m < tm->tm_mon; ++m)
     {
         epoc += palMonthDays[m - 1] * PAL_SECONDS_PER_DAY;
         if (m == PAL_FEB_MONTH && pal_isLeapYear(tm->tm_year))
@@ -403,7 +403,7 @@ palStatus_t pal_plat_x509CertGetAttribute(palX509Handle_t x509Cert, palX509Attr_
                 time.tm_hour = localCtx->crt.valid_from.hour;
                 time.tm_min = localCtx->crt.valid_from.min;
                 time.tm_sec = localCtx->crt.valid_from.sec;
-                time.tm_isdst = -1;                                   //unknown DST 
+                time.tm_isdst = -1;                                   //unknown DST
                 status = pal_timegm(&time, &timeOfDay);
                 if (PAL_SUCCESS != status)
                 {
@@ -416,7 +416,7 @@ palStatus_t pal_plat_x509CertGetAttribute(palX509Handle_t x509Cert, palX509Attr_
             }
             *actualOutLenBytes = PAL_CRYPTO_CERT_DATE_LENGTH;
             break;
-	    
+
         case PAL_X509_VALID_TO:
             if ( PAL_CRYPTO_CERT_DATE_LENGTH > outLenBytes)
             {
@@ -445,10 +445,10 @@ palStatus_t pal_plat_x509CertGetAttribute(palX509Handle_t x509Cert, palX509Attr_
             }
             *actualOutLenBytes = PAL_CRYPTO_CERT_DATE_LENGTH;
             break;
-        
+
         case PAL_X509_CN_ATTR:
             status = pal_plat_X509GetField(localCtx, "CN", output, outLenBytes, actualOutLenBytes);
-            break; 
+            break;
 
         case PAL_X509_L_ATTR:
             status = pal_plat_X509GetField(localCtx, "L", output, outLenBytes, actualOutLenBytes);
@@ -457,7 +457,7 @@ palStatus_t pal_plat_x509CertGetAttribute(palX509Handle_t x509Cert, palX509Attr_
         case PAL_X509_OU_ATTR:
             status = pal_plat_X509GetField(localCtx, "OU", output, outLenBytes, actualOutLenBytes);
             break;
-        
+
         case PAL_X509_CERT_ID_ATTR:
             if (PAL_CERT_ID_SIZE > outLenBytes)
             {
@@ -580,9 +580,9 @@ palStatus_t pal_plat_mdInit(palMDHandle_t* md, palMDType_t mdType)
         goto finish;
     }
 
-    
+
     mbedtls_md_init(&localCtx->md);
-    
+
     switch (mdType)
     {
         case PAL_SHA256:
@@ -615,14 +615,14 @@ palStatus_t pal_plat_mdInit(palMDHandle_t* md, palMDType_t mdType)
                 status = PAL_ERR_CREATION_FAILED;
                 goto finish;
             }
-        default: 
+        default:
             {
                 PAL_LOG(ERR, "Crypto md start setup  %" PRId32 "", platStatus);
                 status = PAL_ERR_GENERIC_FAILURE;
                 goto finish;
             }
     }
-    
+
     platStatus = mbedtls_md_starts(&localCtx->md);
     switch(platStatus)
     {
@@ -633,7 +633,7 @@ palStatus_t pal_plat_mdInit(palMDHandle_t* md, palMDType_t mdType)
                 status = PAL_ERR_MD_BAD_INPUT_DATA;
                 goto finish;
             }
-        default: 
+        default:
             {
                 PAL_LOG(ERR, "Crypto md start status  %" PRId32 "", platStatus);
                 status = PAL_ERR_GENERIC_FAILURE;
@@ -664,7 +664,7 @@ palStatus_t pal_plat_mdUpdate(palMDHandle_t md, const unsigned char* input, size
         case MBEDTLS_ERR_MD_BAD_INPUT_DATA:
             status = PAL_ERR_MD_BAD_INPUT_DATA;
             break;
-        default: 
+        default:
             {
                 PAL_LOG(ERR, "Crypto md update status %" PRId32 "", platStatus);
                 status = PAL_ERR_GENERIC_FAILURE;
@@ -687,7 +687,7 @@ palStatus_t pal_plat_mdGetOutputSize(palMDHandle_t md, size_t* bufferSize)
         PAL_LOG(ERR, "Crypto md get size error");
         status = PAL_ERR_GENERIC_FAILURE;
     }
-    
+
     return status;
 }
 
@@ -705,12 +705,12 @@ palStatus_t pal_plat_mdFinal(palMDHandle_t md, unsigned char* output)
         case MBEDTLS_ERR_MD_BAD_INPUT_DATA:
             status = PAL_ERR_MD_BAD_INPUT_DATA;
             break;
-        default: 
+        default:
             {
                 PAL_LOG(ERR, "Crypto md finish status %" PRId32 "", platStatus);
                 status = PAL_ERR_GENERIC_FAILURE;
             }
-    } 
+    }
     return status;
 }
 
@@ -751,7 +751,7 @@ palStatus_t pal_plat_verifySignature(palX509Handle_t x509, palMDType_t mdType, c
 finish:
     return status;
 }
-#endif 
+#endif
 
 palStatus_t pal_plat_ASN1GetTag(unsigned char **position, const unsigned char *end, size_t *len, uint8_t tag )
 {
@@ -759,7 +759,7 @@ palStatus_t pal_plat_ASN1GetTag(unsigned char **position, const unsigned char *e
     int32_t platStatus = CRYPTO_PLAT_SUCCESS;
     int platTag = 0;
 
-    switch (tag & PAL_ASN1_CLASS_BITS) 
+    switch (tag & PAL_ASN1_CLASS_BITS)
     {
         case 0x00:
             //MBEDTLS_ASN1_PRIMITIVE
@@ -879,7 +879,7 @@ palStatus_t pal_plat_CCMSetKey(palCCMHandle_t ctx, palCipherID_t id, const unsig
     palCCM_t* ccmCtx = (palCCM_t*)ctx;
     mbedtls_cipher_id_t mbedtls_cipher_id;
 
-    switch (id) 
+    switch (id)
     {
         case PAL_CIPHER_ID_AES:
             mbedtls_cipher_id = MBEDTLS_CIPHER_ID_AES;
@@ -1014,7 +1014,7 @@ palStatus_t pal_plat_CtrDRBGGenerateWithAdditional(palCtrDrbgCtxHandle_t ctx, un
     palStatus_t status = PAL_SUCCESS;
     int32_t platStatus = CRYPTO_PLAT_SUCCESS;
     palCtrDrbgCtx_t* palCtrDrbgCtx = (palCtrDrbgCtx_t*)ctx;
-    
+
     platStatus = mbedtls_ctr_drbg_random_with_add(&palCtrDrbgCtx->ctrDrbgCtx, out, len, additional, additionalLen);
     if (CRYPTO_PLAT_SUCCESS != platStatus)
     {
@@ -1150,7 +1150,7 @@ palStatus_t pal_plat_CMACFinish(palCMACHandle_t *ctx, unsigned char *output, siz
         *outLen = localCipher->cipher_info->block_size;
     }
 
-    
+
 
     mbedtls_cipher_free(localCipher);
     free(localCipher);
@@ -1196,7 +1196,7 @@ palStatus_t pal_plat_mdHmacSha256(const unsigned char *key, size_t keyLenInBytes
     return status;
 }
 
-//! Check EC private key function. 
+//! Check EC private key function.
 PAL_PRIVATE palStatus_t pal_plat_ECCheckPrivateKey(palECGroup_t* ecpGroup, palECKeyHandle_t key, bool *verified)
 {
     palStatus_t status = PAL_SUCCESS;
@@ -1219,7 +1219,7 @@ PAL_PRIVATE palStatus_t pal_plat_ECCheckPrivateKey(palECGroup_t* ecpGroup, palEC
     {
         *verified = true;
     }
-    
+
     return status;
 }
 
@@ -1246,7 +1246,7 @@ PAL_PRIVATE palStatus_t pal_plat_ECCheckPublicKey(palECGroup_t* ecpGroup, palECK
     {
         *verified = true;
     }
-    
+
     return status;
 }
 
@@ -1286,7 +1286,7 @@ palStatus_t pal_plat_ECKeyNew(palECKeyHandle_t* key)
         mbedtls_pk_init(localECKey);
         *key = (palECKeyHandle_t)localECKey;
     }
-    
+
     return status;
 }
 
@@ -1482,7 +1482,7 @@ palStatus_t pal_plat_ECKeyGenerateKey(palGroupIndex_t grpID, palECKeyHandle_t ke
         case PAL_ECP_DP_SECP256R1:
             platCurve = MBEDTLS_ECP_DP_SECP256R1;
             break;
-        default: 
+        default:
             status = PAL_ERR_NOT_SUPPORTED_CURVE;
             goto finish;
     }
@@ -1562,7 +1562,7 @@ palStatus_t pal_plat_ECGroupInitAndLoad(palCurveHandle_t* grp, palGroupIndex_t i
         case PAL_ECP_DP_SECP256R1:
             platCurve = MBEDTLS_ECP_DP_SECP256R1;
             break;
-        default: 
+        default:
             status = PAL_ERR_NOT_SUPPORTED_CURVE;
             goto finish;
     }
@@ -1576,7 +1576,7 @@ palStatus_t pal_plat_ECGroupInitAndLoad(palCurveHandle_t* grp, palGroupIndex_t i
     {
         *grp = (palCurveHandle_t)localGroup;
     }
-    
+
 finish:
     if (PAL_SUCCESS != status && localGroup != NULL)
     {
@@ -1611,7 +1611,7 @@ palStatus_t pal_plat_ECDHComputeKey(const palCurveHandle_t grp, const palECKeyHa
             status = PAL_ERR_FAILED_TO_COMPUTE_SHRED_KEY;
         }
     }
-    else 
+    else
     {
         status = PAL_ERR_INVALID_ARGUMENT;
     }
@@ -1704,6 +1704,8 @@ finish:
     return status;
 }
 #if (PAL_ENABLE_X509 == 1)
+
+#if (PAL_ENABLE_X509_WRITE == 1)
 palStatus_t pal_plat_x509CSRInit(palx509CSRHandle_t *x509CSR)
 {
     palStatus_t status = PAL_SUCCESS;
@@ -1779,15 +1781,15 @@ palStatus_t pal_plat_x509CSRSetKey(palx509CSRHandle_t x509CSR, palECKeyHandle_t 
             status = PAL_ERR_INVALID_ARGUMENT;
         }
     }
-    
+
     if (PAL_SUCCESS == status)
     {
         mbedtls_x509write_csr_set_key(localCSR, localPubKey);
     }
-    
+
     return status;
 }
-    
+
 palStatus_t pal_plat_x509CSRSetMD(palx509CSRHandle_t x509CSR, palMDType_t mdType)
 {
     palStatus_t status = PAL_SUCCESS;
@@ -1905,7 +1907,7 @@ palStatus_t pal_plat_x509CSRSetExtendedKeyUsage(palx509CSRHandle_t x509CSR, uint
         goto finish;
     }
 
-    // Set start and end pointer to the used part in value_buf and add the extension to the CSR 
+    // Set start and end pointer to the used part in value_buf and add the extension to the CSR
     start = end;
     end = value_buf + sizeof(value_buf);
     platStatus = mbedtls_x509write_csr_set_extension(localCSR, MBEDTLS_OID_EXTENDED_KEY_USAGE, MBEDTLS_OID_SIZE(MBEDTLS_OID_EXTENDED_KEY_USAGE),
@@ -1969,6 +1971,7 @@ palStatus_t pal_plat_x509CSRFree(palx509CSRHandle_t *x509CSR)
     *x509CSR = NULLPTR;
     return status;
 }
+#endif // PAL_ENABLE_X509_WRITE
 
 palStatus_t pal_plat_x509CertGetHTBS(palX509Handle_t x509Cert, palMDType_t hash_type, unsigned char* output, size_t outLenBytes, size_t* actualOutLenBytes)
 {
@@ -1988,7 +1991,7 @@ palStatus_t pal_plat_x509CertGetHTBS(palX509Handle_t x509Cert, palMDType_t hash_
             status = PAL_ERR_INVALID_MD_TYPE;
             break;
     }
-    
+
     return status;
 }
 
@@ -2003,7 +2006,7 @@ PAL_PRIVATE int pal_plat_entropySource( void *data, unsigned char *output, size_
 {
 	palStatus_t status = PAL_SUCCESS;
     (void)data;
-    
+
     status = pal_osRandomBuffer((uint8_t*) output, len);
     if (PAL_SUCCESS == status)
     {
@@ -2019,7 +2022,7 @@ PAL_PRIVATE int pal_plat_entropySource( void *data, unsigned char *output, size_
 /* This function is provided for ARM-CC compiler, since mbedTLS uses it and it returns NULL
  * in ARM-CC, we need to provide replacement function to keep correct functionality
  * mbedTLS will change the internal implementation which uses gmtime()
- */ 
+ */
 struct tm *gmtime(const time_t *timep)
 {
     return localtime(timep);

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -8,7 +8,8 @@
         "PB_FIELD_32BIT",
         "PB_ENABLE_MALLOC",
         "PB_BUFFER_ONLY",
-        "PV_PROFILE_STD"
+        "PV_PROFILE_STD",
+        "PAL_ENABLE_X509_WRITE=0"
     ],
     "target_overrides": {
         "*": {


### PR DESCRIPTION
Disable this feature flag on Mbed OS - why would it need to create certificates. Saves 4304 bytes of flash on K64F in develop profile.

## Baseline

```
Total Static RAM memory (data + bss): 78212 bytes
Total Flash memory (text + data): 414622 bytes
```

## With these patches

```
Total Static RAM memory (data + bss): 78212 bytes
Total Flash memory (text + data): 410318 bytes
```

@bulislaw 

Verified that K64F still connects and writes resources to Mbed Cloud. Also verified that Update still works.

To see without whitespace changes https://github.com/ARMmbed/mbed-cloud-client/pull/9/files?w=1