### PR TITLE
[Hackathon] Remove standard C++ library dependency

### DIFF
--- a/mbed-client/mbed-client/m2mpair.h
+++ b/mbed-client/mbed-client/m2mpair.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2015-2018 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef M2M_PAIR_H
+#define M2M_PAIR_H
+
+/*! \file m2mpair.h
+* \brief A simple C++ Pair class, used as replacement for std::pair.
+*/
+
+namespace m2m
+{
+    template <typename T1, typename T2>
+    struct Pair {
+        Pair() {} 
+        Pair(const Pair& p) : first(p.first), second(p.second) {} 
+        Pair(const T1& first, const T2& second) : first(first), second(second) {
+        }
+        template <class T3, class T4> Pair& operator=(const Pair<T3, T4>& p) {
+            first = p.first;
+            second = p.second;
+            return *this;
+        }
+
+        T1 first;
+        T2 second;
+    };
+
+} // namespace
+
+#endif // M2M_PAIR_H

--- a/mbed-client/mbed-client/m2mstring.h
+++ b/mbed-client/mbed-client/m2mstring.h
@@ -87,7 +87,7 @@ namespace m2m
     /// swap contents
     void swap( String& );
 
-    String substr(const size_type pos, size_type length) const;
+    String substr(const size_type pos = 0, size_type length = SIZE_MAX) const;
 
     // unchecked access:
     char& operator[](const size_type i)       { return p[i]; }
@@ -110,6 +110,7 @@ namespace m2m
     int compare( size_type pos, size_type len, const String& str ) const;
     int compare( size_type pos, size_type len, const char*   str ) const;
 
+    size_t find_first_of (const char* s, size_t pos = 0) const {}
     int find_last_of(char c) const;
 
     static uint8_t* convert_integer_to_array(int64_t value, uint8_t &size, const uint8_t *array = NULL, const uint32_t array_size = 0);

--- a/mbed-client/mbed-client/m2mstring.h
+++ b/mbed-client/mbed-client/m2mstring.h
@@ -110,8 +110,9 @@ namespace m2m
     int compare( size_type pos, size_type len, const String& str ) const;
     int compare( size_type pos, size_type len, const char*   str ) const;
 
-    size_t find_first_of (char c) const;
+    size_t find_first_of (char c, size_t pos = 0) const;
     size_t find_last_of(char c) const;
+    size_t find(char c, size_t pos = 0) const;
 
     static uint8_t* convert_integer_to_array(int64_t value, uint8_t &size, const uint8_t *array = NULL, const uint32_t array_size = 0);
     static int64_t convert_array_to_integer(const uint8_t *value, const uint32_t size);

--- a/mbed-client/mbed-client/m2mstring.h
+++ b/mbed-client/mbed-client/m2mstring.h
@@ -87,7 +87,7 @@ namespace m2m
     /// swap contents
     void swap( String& );
 
-    String substr(const size_type pos = 0, size_type length = SIZE_MAX) const;
+    String substr(const size_type pos = 0, size_type length = String::npos) const;
 
     // unchecked access:
     char& operator[](const size_type i)       { return p[i]; }
@@ -110,7 +110,7 @@ namespace m2m
     int compare( size_type pos, size_type len, const String& str ) const;
     int compare( size_type pos, size_type len, const char*   str ) const;
 
-    size_t find_first_of (const char* s, size_t pos = 0) const {}
+    size_t find_first_of (char c) const;
     int find_last_of(char c) const;
 
     static uint8_t* convert_integer_to_array(int64_t value, uint8_t &size, const uint8_t *array = NULL, const uint32_t array_size = 0);

--- a/mbed-client/mbed-client/m2mstring.h
+++ b/mbed-client/mbed-client/m2mstring.h
@@ -111,7 +111,7 @@ namespace m2m
     int compare( size_type pos, size_type len, const char*   str ) const;
 
     size_t find_first_of (char c) const;
-    int find_last_of(char c) const;
+    size_t find_last_of(char c) const;
 
     static uint8_t* convert_integer_to_array(int64_t value, uint8_t &size, const uint8_t *array = NULL, const uint32_t array_size = 0);
     static int64_t convert_array_to_integer(const uint8_t *value, const uint32_t size);

--- a/mbed-client/mbed-client/m2munorderedmap.h
+++ b/mbed-client/mbed-client/m2munorderedmap.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2015-2018 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef M2M_UNORDERED_MAP_H
+#define M2M_UNORDERED_MAP_H
+
+/*! \file m2mpair.h
+* \brief A simple C++ Map class, used as replacement for std::unordered_map.
+* This map is implemented as a vector of Pair<Key, Value>. Searching is therefore O(N) and not O(1), 
+* however for small-ish quantity of data this will be perfectly acceptable. 
+* The main drawback of this implementation is that erasing objects is expensive and invalidates iterators.
+*/
+
+#include "m2mvector.h"
+#include "m2mpair.h"
+
+namespace m2m
+{
+
+    template <typename Key, typename Value>
+    class UnorderedMap {
+    public:
+        typedef typename Vector<Pair<Key, Value> >::iterator iterator;
+        typedef typename Vector<Pair<Key, Value> >::const_iterator const_iterator;
+
+        Value& operator[](const Key& key) {
+            // Find or insert default constructed value
+            Pair<iterator, bool> p = insert(Pair<Key, Value>(key, Value()));
+            return p.first->second;
+        }
+
+        iterator find( const Key& key ) {
+            iterator it = _kv_pairs.begin();
+            
+            while(it != _kv_pairs.end())
+            {
+                if( it->first == key ) { 
+                    // Found
+                    break;
+                }
+                it++;
+            }
+
+            return it;
+        }
+	
+        const_iterator find( const Key& key ) const {
+            const_iterator it = _kv_pairs.begin();
+            
+            while(it != _kv_pairs.end())
+            {
+                if( it->first == key ) { 
+                    // Found
+                    break;
+                }
+                it++;
+            }
+
+            return it;
+        }
+
+        iterator begin() {
+            return _kv_pairs.begin();
+        }
+
+        const_iterator begin() const {
+            return _kv_pairs.begin();
+        }
+
+        iterator end() {
+            return _kv_pairs.end();
+        }
+
+        const_iterator end() const {
+            return _kv_pairs.end();
+        }
+
+        size_t count(const Key& key) const {
+            if( find(key) != end() )
+            {
+                return 1;
+            }
+            else 
+            {
+                return 0;
+            }
+        }
+
+        Pair<iterator, bool> insert(const Pair<Key, Value>& val) {
+            iterator it = find(val.first);
+            if( it != end() )
+            {
+                return Pair<iterator, bool>(it, false);
+            }
+            else 
+            {
+                _kv_pairs.push_back(val);
+                it = _kv_pairs.end();
+                it--;
+                return Pair<iterator, bool>(it, true);
+            }
+        }
+
+        // Note: This is the subset of methods required by MCC - obviously there's a bunch of methods missing
+
+    private:
+        Vector<Pair<Key, Value> > _kv_pairs;
+    };
+
+} // namespace
+
+#endif // M2M_UNORDERED_MAP_H

--- a/mbed-client/mbed-client/m2mvector.h
+++ b/mbed-client/mbed-client/m2mvector.h
@@ -147,6 +147,14 @@ class Vector
         }
     }
 
+    ObjectTemplate & at(int idx) {
+        return _object_template[idx];
+    }
+
+    const ObjectTemplate& at(int idx) const {
+        return _object_template[idx];
+    }
+
     enum {
         MIN_CAPACITY = 1
     };

--- a/mbed-client/source/m2mstring.cpp
+++ b/mbed-client/source/m2mstring.cpp
@@ -295,19 +295,15 @@ size_t String::find_first_of (char c) const {
     return char_pos - p;
 }
 
-int String::find_last_of(char c) const {
-    int r = -1;
-    char *v;
-    v = strrchr(p,c);
-    if (v != NULL) {
-        r = 0;
-        char* i = p;
-        while (v != i) {
-            i++;
-            r++;
-        }
+size_t String::find_last_of(char c) const {
+    char* char_pos = strrchr(p , c); // p is the C-string backing this implementation
+    if(char_pos == NULL) {
+        // Not found
+        return String::npos;
     }
-    return r;
+
+    // Otherwise return the character's position within the string
+    return char_pos - p;
 }
 
 void String::new_realloc( size_type n) {

--- a/mbed-client/source/m2mstring.cpp
+++ b/mbed-client/source/m2mstring.cpp
@@ -284,6 +284,17 @@ int String::compare( size_type pos, size_type len, const char* str ) const {
     return r;
 }
 
+size_t String::find_first_of (char c) const {
+    char* char_pos = strchr(p , c); // p is the C-string backing this implementation
+    if(char_pos == NULL) {
+        // Not found
+        return String::npos;
+    }
+
+    // Otherwise return the character's position within the string
+    return char_pos - p;
+}
+
 int String::find_last_of(char c) const {
     int r = -1;
     char *v;

--- a/mbed-client/source/m2mstring.cpp
+++ b/mbed-client/source/m2mstring.cpp
@@ -284,8 +284,17 @@ int String::compare( size_type pos, size_type len, const char* str ) const {
     return r;
 }
 
-size_t String::find_first_of (char c) const {
-    char* char_pos = strchr(p , c); // p is the C-string backing this implementation
+size_t String::find_first_of (char c, size_t pos) const {
+    char* str = p; // p is the C-string backing this implementation
+
+    if( pos >= size() ) // Past the end
+    {
+        return String::npos;
+    }
+
+    str += pos;
+
+    char* char_pos = strchr(str , c);
     if(char_pos == NULL) {
         // Not found
         return String::npos;
@@ -304,6 +313,11 @@ size_t String::find_last_of(char c) const {
 
     // Otherwise return the character's position within the string
     return char_pos - p;
+}
+
+size_t String::find(char c, size_t pos) const
+{
+    return find_first_of(c, pos);
 }
 
 void String::new_realloc( size_type n) {

--- a/mbed-cloud-client/MbedCloudClient.h
+++ b/mbed-cloud-client/MbedCloudClient.h
@@ -20,13 +20,77 @@
 #ifndef __MBED_CLOUD_CLIENT_H__
 #define __MBED_CLOUD_CLIENT_H__
 
-#include <map>
-#include <string>
-#include <vector>
 #include "include/ServiceClient.h"
 #include "mbed-cloud-client/MbedCloudClientConfig.h"
 
-using namespace std;
+#include "mbed-client/m2mvector.h"
+#include "mbed-client/m2mstring.h"
+
+namespace m2m
+{
+    template <typename First, typename Second>
+    struct Pair {
+        Pair() {} 
+        Pair(const Pair& p) {} 
+        Pair(const First& first, const Second& second) {
+
+        }
+
+        First first;
+        Second second;
+    };
+
+    template <typename Key, typename Value>
+    struct UnorderedMap {
+        typedef typename Vector<Pair<Key, Value> >::iterator iterator;
+        typedef typename Vector<Pair<Key, Value> >::const_iterator const_iterator;
+
+        Value& operator[](const Key& key) {
+            // Find or push and create
+            iterator it = find(key);
+
+            return it->second;
+        }
+
+        const Value& operator[](const Key& key) const {
+            // Find or fail
+            const_iterator it = find(key);
+
+            return it->second;
+        }
+
+        iterator find( const Key& key ) {
+
+        }
+	
+        const_iterator find( const Key& key ) const {
+
+        }
+
+        iterator begin() {
+        }
+
+        const_iterator begin() const {
+        }
+
+        iterator end() {
+        }
+
+        const_iterator end() const {
+        }
+
+        size_t count(const Key& key) const {
+            //return _kv_pairs.size();
+        }
+
+        Pair<iterator, bool> insert (const Pair<Key, Value>& val) {
+
+        }
+    private:
+        Vector<Pair<Key, Value> > _kv_pairs;
+    };
+}
+
 class SimpleM2MResourceBase;
 
 /**
@@ -300,7 +364,7 @@ public:
      * \return True if successful, false otherwise.
      */
     bool set_device_resource_value(M2MDevice::DeviceResource resource,
-                                   const std::string &value);
+                                   const m2m::String &value);
 
 #ifdef MBED_CLOUD_CLIENT_SUPPORT_UPDATE
     /**
@@ -375,16 +439,16 @@ private:
     * \param route The URI path of the registered resource such as "/Test/0/res/".
     * \param resource Object of the SimpleM2MResourceBase.
     */
-    void register_update_callback(string route, SimpleM2MResourceBase* resource);
+    void register_update_callback(m2m::String route, SimpleM2MResourceBase* resource);
 
 private:
 
     ServiceClient                                   _client;
     MbedCloudClientCallback                         *_value_callback;
-    map<string, M2MObject*>                         _objects;
-    map<string, M2MResource*>                       _resources;
+    m2m::UnorderedMap<m2m::String, M2MObject*>               _objects;
+    m2m::UnorderedMap<m2m::String, M2MResource*>             _resources;
     M2MBaseList                                     _object_list;
-    map<string, SimpleM2MResourceBase*>             _update_values;
+    m2m::UnorderedMap<m2m::String, SimpleM2MResourceBase*>   _update_values;
     FP0<void>                                       _on_registered;
     FP0<void>                                       _on_unregistered;
     FP0<void>                                       _on_registration_updated;

--- a/mbed-cloud-client/MbedCloudClient.h
+++ b/mbed-cloud-client/MbedCloudClient.h
@@ -25,71 +25,8 @@
 
 #include "mbed-client/m2mvector.h"
 #include "mbed-client/m2mstring.h"
+#include "mbed-client/m2munorderedmap.h"
 
-namespace m2m
-{
-    template <typename First, typename Second>
-    struct Pair {
-        Pair() {} 
-        Pair(const Pair& p) {} 
-        Pair(const First& first, const Second& second) {
-
-        }
-
-        First first;
-        Second second;
-    };
-
-    template <typename Key, typename Value>
-    struct UnorderedMap {
-        typedef typename Vector<Pair<Key, Value> >::iterator iterator;
-        typedef typename Vector<Pair<Key, Value> >::const_iterator const_iterator;
-
-        Value& operator[](const Key& key) {
-            // Find or push and create
-            iterator it = find(key);
-
-            return it->second;
-        }
-
-        const Value& operator[](const Key& key) const {
-            // Find or fail
-            const_iterator it = find(key);
-
-            return it->second;
-        }
-
-        iterator find( const Key& key ) {
-
-        }
-	
-        const_iterator find( const Key& key ) const {
-
-        }
-
-        iterator begin() {
-        }
-
-        const_iterator begin() const {
-        }
-
-        iterator end() {
-        }
-
-        const_iterator end() const {
-        }
-
-        size_t count(const Key& key) const {
-            //return _kv_pairs.size();
-        }
-
-        Pair<iterator, bool> insert (const Pair<Key, Value>& val) {
-
-        }
-    private:
-        Vector<Pair<Key, Value> > _kv_pairs;
-    };
-}
 
 class SimpleM2MResourceBase;
 

--- a/mbed-cloud-client/SimpleM2MResource.h
+++ b/mbed-cloud-client/SimpleM2MResource.h
@@ -42,7 +42,7 @@ protected:
     // Prevents the use of copy constructor
     SimpleM2MResourceBase( const M2MBase& /*other*/ );
 
-    SimpleM2MResourceBase(MbedCloudClient* client, string route);
+    SimpleM2MResourceBase(MbedCloudClient* client, m2m::String route);
 
     /**
      * \brief Destructor
@@ -61,7 +61,7 @@ public:
      * \param observable True if the resource is observable, else false.
      * \return True if resource is created, else false.
      */
-    bool define_resource_internal(string v,
+    bool define_resource_internal(m2m::String v,
                                   M2MBase::Operation opr,
                                   bool observable);
 
@@ -69,14 +69,14 @@ public:
      * \brief Gets the value set in a resource in text format.
      * \return The value set in the resource.
      */
-    string get() const;
+    m2m::String get() const;
 
     /**
      * \brief Sets the value in a resource in text format.
      * \param v The value to be set.
      * \return True if set successfully, else false.
      */
-    bool set(string v);
+    bool set(m2m::String v);
 
     /**
      * \brief Sets the value in a resource in integer format.
@@ -124,11 +124,11 @@ private:
     * \param route The URI path in the format "Test/0/res".
     * \return A list of strings parsed from the URI path.
     */
-    vector<string> parse_route(const char* route);
+    m2m::Vector<m2m::String> parse_route(const char* route);
 
 private:
     MbedCloudClient*                    _client;   // Not owned
-    string                              _route;
+    m2m::String                              _route;
 };
 
 /**
@@ -155,10 +155,10 @@ public:
      */
     SimpleM2MResourceString(MbedCloudClient* client,
                    const char* route,
-                   string v,
+                   m2m::String v,
                    M2MBase::Operation opr = M2MBase::GET_PUT_ALLOWED,
                    bool observable = true,
-                   FP1<void, string> on_update = NULL);
+                   FP1<void, m2m::String> on_update = NULL);
 
     /**
      *  \brief Constructor. This is overloaded function.
@@ -173,10 +173,10 @@ public:
      */
     SimpleM2MResourceString(MbedCloudClient* client,
                    const char* route,
-                   string v,
+                   m2m::String v,
                    M2MBase::Operation opr,
                    bool observable,
-                   void(*on_update)(string));
+                   void(*on_update)(m2m::String));
 
 
     /**
@@ -187,12 +187,12 @@ public:
     /**
      * \brief Overloaded operator for = operation.
      */
-    string operator=(const string& new_value);
+    m2m::String operator=(const m2m::String& new_value);
 
     /**
      * \brief Overloaded operator for string() operation.
      */
-    operator string() const;
+    operator m2m::String() const;
 
     /**
     * \brief Calls when there is an indication that the value of the resource
@@ -201,7 +201,7 @@ public:
     virtual void update();
 
 private:
-    FP1<void, string>                   _on_update;
+    FP1<void, m2m::String>                   _on_update;
 };
 
 /**

--- a/source/MbedCloudClient.cpp
+++ b/source/MbedCloudClient.cpp
@@ -91,7 +91,7 @@ bool MbedCloudClient::setup(void* iface)
 {
     tr_debug("MbedCloudClient setup()");
     // Add objects to list
-    map<string, M2MObject*>::iterator it;
+    m2m::UnorderedMap<m2m::String, M2MObject*>::iterator it;
     for (it = _objects.begin(); it != _objects.end(); it++)
     {
         _object_list.push_back((M2MBase*)it->second);
@@ -163,7 +163,7 @@ void MbedCloudClient::set_entropy_callback(entropy_cb callback)
 }
 
 bool MbedCloudClient::set_device_resource_value(M2MDevice::DeviceResource resource,
-                                                const std::string &value)
+                                                const m2m::String &value)
 {
     return _client.set_device_resource_value(resource, value);
 }
@@ -191,7 +191,7 @@ const char *MbedCloudClient::error_description() const
 }
 
 
-void MbedCloudClient::register_update_callback(string route,
+void MbedCloudClient::register_update_callback(m2m::String route,
                                                SimpleM2MResourceBase* resource)
 {
     _update_values[route] = resource;

--- a/source/ServiceClient.cpp
+++ b/source/ServiceClient.cpp
@@ -23,7 +23,6 @@
 #endif
 #include <inttypes.h>
 
-#include <string>
 #include "include/ServiceClient.h"
 #include "include/CloudClientStorage.h"
 #include "include/UpdateClientResources.h"
@@ -465,7 +464,7 @@ M2MDevice* ServiceClient::device_object_from_storage()
  * \return True if successful, false otherwise.
  */
 bool ServiceClient::set_device_resource_value(M2MDevice::DeviceResource resource,
-                                              const std::string& value)
+                                              const m2m::String& value)
 {
     return set_device_resource_value(resource,
                                      value.c_str(),

--- a/source/SimpleM2MResource.cpp
+++ b/source/SimpleM2MResource.cpp
@@ -107,12 +107,12 @@ m2m::Vector<m2m::String> SimpleM2MResourceBase::parse_route(const char* route)
 {
     m2m::String s(route);
     m2m::Vector<m2m::String> v;
-    size_t found = s.find_first_of("/");
+    size_t found = s.find_first_of('/');
 
     while (found!=m2m::String::npos) {
         v.push_back(s.substr(0,found));
         s = s.substr(found+1);
-        found=s.find_first_of("/");
+        found=s.find_first_of('/');
         if(found == m2m::String::npos) {
             v.push_back(s);
         }

--- a/source/include/ServiceClient.h
+++ b/source/include/ServiceClient.h
@@ -27,7 +27,7 @@
 #include "mbed-client/m2mdevice.h"
 #include "ConnectorClient.h"
 
-#include <string>
+#include "mbed-client/m2mstring.h"
 
 class M2MSecurity;
 class ConnectorClientCallback;
@@ -140,7 +140,7 @@ public:
      * \return True if successful, false otherwise.
      */
     bool set_device_resource_value(M2MDevice::DeviceResource resource,
-                                   const std::string& value);
+                                   const m2m::String& value);
 
     /**
      * \brief Set resource value in the Device Object


### PR DESCRIPTION
This PR removes dependencies on the standard C++ library by:
* Removing all uses of `std::string`, `std::map`, `std::pair`, `std::vector`
* Using containers provided by the client in the `m2m` namespace and extending them where required (string)
* Creating missing `m2m` containers: `Pair` and `UnorderedMap`

This PR saves **15.43kB of ROM** with GCC_ARM in the release profile when using the simple MCC example. I also expect that it will eliminate significant heap allocations. 