### PR TITLE
Don't use atomic intrinsics for uARM

### DIFF
--- a/update-client-hub/modules/atomic-queue/source/atomic.c
+++ b/update-client-hub/modules/atomic-queue/source/atomic.c
@@ -52,7 +52,7 @@ int aq_atomic_cas_deref_uintptr(uintptr_t* volatile * ptrAddr,
 #endif
 
 
-#if defined(__GNUC__) && (!defined(__CORTEX_M) || (__CORTEX_M >= 0x03))
+#if defined(__GNUC__) && (!defined(__CORTEX_M) || (__CORTEX_M >= 0x03)) && (!defined(__MICROLIB))
 int aq_atomic_cas_uintptr(uintptr_t *ptr, uintptr_t oldval, uintptr_t newval) {
     return __sync_bool_compare_and_swap(ptr, oldval, newval);
 }


### PR DESCRIPTION
Don't use atomic intrinsics for uARM so linking works for this toolchain.