### PR TITLE
Making FlashIAP object SingletonPtr

### DIFF
--- a/update-client-hub/modules/pal-flashiap/source/arm_uc_pal_flashiap_mbed.cpp
+++ b/update-client-hub/modules/pal-flashiap/source/arm_uc_pal_flashiap_mbed.cpp
@@ -21,7 +21,7 @@
 #include "update-client-pal-flashiap/arm_uc_pal_flashiap_platform.h"
 #include "mbed.h"
 
-static FlashIAP flash;
+SingletonPtr<FlashIAP> flash;
 
 int32_t arm_uc_flashiap_init(void)
 {
@@ -29,23 +29,23 @@ int32_t arm_uc_flashiap_init(void)
      * pal_init calls flash.init() before here. Second call to flash.init() will
      * return -1 error state. Hence we ignore the result of flash.init here.
      */
-    flash.init();
+    flash->init();
     return 0;
 }
 
 int32_t arm_uc_flashiap_erase(uint32_t address, uint32_t size)
 {
-    return flash.erase(address, size);
+    return flash->erase(address, size);
 }
 
 int32_t arm_uc_flashiap_program(const uint8_t* buffer, uint32_t address, uint32_t size)
 {
-    uint32_t page_size = flash.get_page_size();
+    uint32_t page_size = flash->get_page_size();
     int status = ARM_UC_FLASHIAP_FAIL;
 
     for (uint32_t i = 0; i < size; i += page_size)
     {
-        status = flash.program(buffer+i, address+i, page_size);
+        status = flash->program(buffer+i, address+i, page_size);
         if (status != ARM_UC_FLASHIAP_SUCCESS)
         {
             break;
@@ -57,17 +57,17 @@ int32_t arm_uc_flashiap_program(const uint8_t* buffer, uint32_t address, uint32_
 
 int32_t arm_uc_flashiap_read(uint8_t* buffer, uint32_t address, uint32_t size)
 {
-    return flash.read(buffer, address, size);
+    return flash->read(buffer, address, size);
 }
 
 uint32_t arm_uc_flashiap_get_page_size(void)
 {
-    return flash.get_page_size();
+    return flash->get_page_size();
 }
 
 uint32_t arm_uc_flashiap_get_sector_size(uint32_t address)
 {
-    uint32_t sector_size = flash.get_sector_size(address);
+    uint32_t sector_size = flash->get_sector_size(address);
     if (sector_size == ARM_UC_FLASH_INVALID_SIZE || sector_size == 0)
     {
         return ARM_UC_FLASH_INVALID_SIZE;
@@ -80,11 +80,11 @@ uint32_t arm_uc_flashiap_get_sector_size(uint32_t address)
 
 uint32_t arm_uc_flashiap_get_flash_size(void)
 {
-    return flash.get_flash_size();
+    return flash->get_flash_size();
 }
 
 uint32_t arm_uc_flashiap_get_flash_start(void)
 {
-    return flash.get_flash_start();
+    return flash->get_flash_start();
 }
 #endif


### PR DESCRIPTION
Any object left lingering in the source code with static initializer will get pulled in even if not being used.
That's why FlashIAP object should be wrapped in SingeltonPtr envelope.
This will save about 660 B of ROM and 40 B of RAM for applications who do have mbed-clount-client library but are not using it.