### PR TITLE
make MbedCloudClientCallback dtor virtual

### DIFF
--- a/mbed-cloud-client/MbedCloudClient.h
+++ b/mbed-cloud-client/MbedCloudClient.h
@@ -49,6 +49,8 @@ class MbedCloudClientCallback {
 
 public:
 
+    virtual ~MbedCloudClientCallback();
+    
     /**
     * \brief A callback indicating that the value of the resource object is updated
     *  by the LWM2M Cloud server.


### PR DESCRIPTION
In order to prevent a possible resource leak in the derived class, make base class dtor virtual.

* also consider adding 
virtual ~MbedCloudClientCallback(){};
instead of
virtual ~MbedCloudClientCallback();

