### PR TITLE
pv_log.h: Avoid C++11 user-defined literal

### DIFF
--- a/factory-configurator-client/logger/logger/pv_log.h
+++ b/factory-configurator-client/logger/logger/pv_log.h
@@ -165,7 +165,7 @@ do{ \
         mbed_tracef(level, "fcc","%s:%d:%s:" format, file, line, func, ##__VA_ARGS__);\
 } while (0)
 
-#define _SA_PV_BYTE_BUFF_LOG(level, file, line, func, name, buff, buff_size) ( mbed_tracef(level, "fcc", "%s"name, mbed_trace_array(buff, buff_size)))
+#define _SA_PV_BYTE_BUFF_LOG(level, file, line, func, name, buff, buff_size) ( mbed_tracef(level, "fcc", "%s" name, mbed_trace_array(buff, buff_size)))
 
 #undef __PV_LOG_H__INSIDE
 


### PR DESCRIPTION
Make pv_log.h C++11 compatible by adding a space. This was also sent upstream to the internal repository.

Credit: @kjbracey-arm