### PR TITLE
mbed: Don't depend on MBEDTLS_PSA_HAS_ITS_IO

### DIFF
--- a/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/mbedOS/Entropy/pal_plat_entropy_mbed.c
+++ b/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/mbedOS/Entropy/pal_plat_entropy_mbed.c
@@ -16,9 +16,7 @@
 // limitations under the License.
 // ----------------------------------------------------------------------------
 
-// MBEDTLS_PSA_HAS_ITS_IO is defined by default in mbed_lib.json of mbedcrypto (part of mbed-os)
-// and therefore is visible througout the entire code
-#if defined(MBEDTLS_PSA_HAS_ITS_IO) && defined(MBED_CONF_MBED_CLOUD_CLIENT_EXTERNAL_SST_SUPPORT)
+#if defined(MBED_CONF_MBED_CLOUD_CLIENT_EXTERNAL_SST_SUPPORT)
 
 #include "pal.h"
 #include "pal_plat_entropy.h"


### PR DESCRIPTION
It is no longer necessary, as of Mbed Crypto 1.1.0, to tell Mbed Crypto
that the ITS API is available. As such, Mbed OS may in the future no
longer define this macro, since Mbed Crypto doesn't consume it. Instead,
the ITS API is assumed to be available on all PSA targets, and is
implemented with either files (when Mbed Crypto is configured with
MBEDTLS_PSA_ITS_FILE_C) or by the OS (the default).

Because Mbed OS may no longer define MBEDTLS_PSA_HAS_ITS_IO in the
future, the definition of pal_plat_osEntropyInject() shouldn't be
conditional on its presence, lest one run into linker errors with that
function not being available for linking.

```
    Link: mbed-cloud-client-example
    Link: /usr/local/ARM_Compiler_5.06u3/bin/armlink --via ./BUILD/K64F/ARM/.link_options.txt
    [DEBUG] Return: 1
    [Warning] kx4n9I@127,3: L6312W: Empty Execution region description for region RW_IRAM1
    [DEBUG] Errors: "/tmp/kx4n9I", line 127 (column 3): Warning: L6312W: Empty Execution region description for region RW_IRAM1
    [DEBUG] Errors: Error: L6218E: Undefined symbol pal_plat_osEntropyInject (referred from BUILD/K64F/ARM/mbed-cloud-client/mbed-client-pal/Source/PAL-Impl/Modules/Entropy/pal_entropy.o).
    [DEBUG] Errors: Finished: 0 information, 1 warning and 1 error messages.
    Traceback (most recent call last):
      File "mbed-cloud-client-example/mbed-os/tools/make.py", line 78, in wrapped_build_project
        *args, **kwargs
      File "mbed-cloud-client-example/mbed-os/tools/build_api.py", line 598, in build_project
        res = toolchain.link_program(resources, build_path, name)
      File "mbed-cloud-client-example/mbed-os/tools/toolchains/mbed_toolchain.py", line 739, in link_program
        self.link(elf, objects, libraries, lib_dirs, linker_script)
      File "mbed-cloud-client-example/mbed-os/tools/toolchains/arm.py", line 339, in link
        self.default_cmd(cmd)
      File "mbed-cloud-client-example/mbed-os/tools/toolchains/mbed_toolchain.py", line 791, in default_cmd
        raise ToolException(stderr)
    ToolException: "/tmp/kx4n9I", line 127 (column 3): Warning: L6312W: Empty Execution region description for region RW_IRAM1
    Error: L6218E: Undefined symbol pal_plat_osEntropyInject (referred from BUILD/K64F/ARM/mbed-cloud-client/mbed-client-pal/Source/PAL-Impl/Modules/Entropy/pal_entropy.o).
    Finished: 0 information, 1 warning and 1 error messages.
```