### PR TITLE
Async DNS callback for multiple DNS feature  

### DIFF
--- a/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/mbedOS/Networking/pal_plat_network.cpp
+++ b/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/mbedOS/Networking/pal_plat_network.cpp
@@ -1130,7 +1130,7 @@ void pal_plat_getAddressInfoAsync_callback(void *data, nsapi_error_t result, Soc
     palStatus_t status = PAL_SUCCESS;
     pal_asyncAddressInfo_t* info = (pal_asyncAddressInfo_t*)(data);
 
-    if (result == NSAPI_ERROR_OK) {
+    if (result >= NSAPI_ERROR_OK) {
         status = socketAddressToPalSockAddr(*address, info->address);
     }
     else { // error happened


### PR DESCRIPTION
New feature for multiple DNS records is added to Mbed-OS.  
Both async gethostbyname and async getaddrinfo use one DNS callback type.
Now it gets number of found DNS records.
Returned async result is greater than NSAPI_ERROR_OK so check is modified.

To avoid dependency errors until  Mbed and Cloud Client merge temporary solution is used
"result >= NSAPI_ERROR_OK" instead of final "result > NSAPI_ERROR_OK"

@teetak01 
@michalpaszta
@AnttiKauppila