### PR TITLE
Fixed m2m::String vs std::String ambiguity

### DIFF
--- a/mbed-client/mbed-client/m2mbase.h
+++ b/mbed-client/mbed-client/m2mbase.h
@@ -252,10 +252,10 @@ protected:
      * \param external_blockwise_store If true CoAP blocks are passed to application through callbacks
      *        otherwise handled in mbed-client-c.
      */
-    M2MBase(const String &name,
+    M2MBase(const m2m::String &name,
             M2MBase::Mode mode,
 #ifndef DISABLE_RESOURCE_TYPE
-            const String &resource_type,
+            const m2m::String &resource_type,
 #endif
             char *path,
             bool external_blockwise_store,
@@ -283,7 +283,7 @@ public:
      * \param description The description to be set.
      */
 #if !defined(DISABLE_INTERFACE_DESCRIPTION) || defined(RESOURCE_ATTRIBUTES_LIST)
-    void set_interface_description(const String &description);
+    void set_interface_description(const m2m::String &description);
 
     /**
      * \brief Sets the interface description of the object.
@@ -302,7 +302,7 @@ public:
      * \brief Sets the resource type of the object.
      * \param resource_type The resource type to be set.
      */
-    virtual void set_resource_type(const String &resource_type);
+    virtual void set_resource_type(const m2m::String &resource_type);
 
     /**
      * \brief Sets the resource type of the object.
@@ -571,7 +571,7 @@ public:
      * @brief Calls the function that is set in the "set_value_updated_function".
      * @param name The name of the object.
      */
-    void execute_value_updated(const String& name);
+    void execute_value_updated(const m2m::String& name);
 
     /**
      * @brief Returns length of the object name.
@@ -720,7 +720,7 @@ protected: // from M2MReportObserver
     static uint8_t* alloc_copy(const uint8_t* source, uint32_t size);
 
     // validate string length to be [min_length..max_length]
-    static bool validate_string_length(const String &string, size_t min_length, size_t max_length);
+    static bool validate_string_length(const m2m::String &string, size_t min_length, size_t max_length);
     static bool validate_string_length(const char* string, size_t min_length, size_t max_length);
 
     /**
@@ -849,7 +849,7 @@ protected: // from M2MReportObserver
 
 private:
 
-    static bool is_integer(const String &value);
+    static bool is_integer(const m2m::String &value);
 
     static bool is_integer(const char *value);
 

--- a/mbed-client/mbed-client/m2mdevice.h
+++ b/mbed-client/mbed-client/m2mdevice.h
@@ -106,7 +106,7 @@ public:
      * \param value The value to be set on the resource, in string format.
      * \return M2MResource if created successfully, else NULL.
      */
-    M2MResource* create_resource(DeviceResource resource, const String &value);
+    M2MResource* create_resource(DeviceResource resource, const m2m::String &value);
 
     /**
      * \brief Creates a new resource for the given resource enum.
@@ -168,7 +168,7 @@ public:
      * \return True if successfully set, else false.
      */
     bool set_resource_value(DeviceResource resource,
-                            const String &value,
+                            const m2m::String &value,
                             uint16_t instance_id = 0);
 
     /**
@@ -194,7 +194,7 @@ public:
      * \param instance_id The instance ID of the resource, default is 0.
      * \return The value associated with that resource. If the resource is not valid NULL is returned.
      */
-    String resource_value_string(DeviceResource resource,
+    m2m::String resource_value_string(DeviceResource resource,
                                  uint16_t instance_id = 0) const;
 
     /**

--- a/mbed-client/mbed-client/m2minterface.h
+++ b/mbed-client/mbed-client/m2minterface.h
@@ -286,20 +286,20 @@ public:
      * @brief Updates the endpoint name.
      * @param name New endpoint name
      */
-    virtual void update_endpoint(const String &name) = 0;
+    virtual void update_endpoint(const m2m::String &name) = 0;
 
     /**
      * @brief Updates the domain name.
      * @param domain New domain name
      */
-    virtual void update_domain(const String &domain) = 0;
+    virtual void update_domain(const m2m::String &domain) = 0;
 
 
     /**
      * @brief Return internal endpoint name
      * @return internal endpoint name
      */
-    virtual const String internal_endpoint_name() const = 0;
+    virtual const m2m::String internal_endpoint_name() const = 0;
 
     /**
      * @brief Return error description for the latest error code

--- a/mbed-client/mbed-client/m2minterfacefactory.h
+++ b/mbed-client/mbed-client/m2minterfacefactory.h
@@ -61,14 +61,14 @@ public:
      * \return M2MInterfaceImpl An object for managing other client operations.
      */
     static M2MInterface *create_interface(M2MInterfaceObserver &observer,
-                                              const String &endpoint_name,
-                                              const String &endpoint_type = "",
+                                              const m2m::String &endpoint_name,
+                                              const m2m::String &endpoint_type = "",
                                               const int32_t life_time = -1,
                                               const uint16_t listen_port = 5683,
-                                              const String &domain = "",
+                                              const m2m::String &domain = "",
                                               M2MInterface::BindingMode mode = M2MInterface::NOT_SET,
                                               M2MInterface::NetworkStack stack = M2MInterface::LwIP_IPv4,
-                                              const String &context_address = "");
+                                              const m2m::String &context_address = "");
 
     /**
      * \brief Creates a security object for the mbed Client Inteface. With this, the
@@ -110,7 +110,7 @@ public:
      * \param name The name of the object.
      * \return M2MObject An object for managing other mbed Client operations.
      */
-    static M2MObject *create_object(const String &name);
+    static M2MObject *create_object(const m2m::String &name);
 
     /**
      * \brief Creates a M2M resource and places it to the given object list.
@@ -144,7 +144,7 @@ public:
      * \param name The name of the object.
      * \return M2MObject An object for managing other mbed Client operations.
      */
-    static M2MEndpoint* create_endpoint(const String &name);
+    static M2MEndpoint* create_endpoint(const m2m::String &name);
 #endif
 
 private:

--- a/mbed-client/mbed-client/m2mobject.h
+++ b/mbed-client/mbed-client/m2mobject.h
@@ -52,7 +52,7 @@ protected :
      * \param external_blockwise_store If true, CoAP blocks are passed to application through callbacks,
      *        otherwise handled in mbed-client-c.
      */
-    M2MObject(const String &object_name,
+    M2MObject(const m2m::String &object_name,
               char *path,
               bool external_blockwise_store = false);
 

--- a/mbed-client/mbed-client/m2mobjectinstance.h
+++ b/mbed-client/mbed-client/m2mobjectinstance.h
@@ -47,7 +47,7 @@ private: // Constructor and destructor are private which means
      * \param name Name of the object
      */
     M2MObjectInstance(M2MObject& parent,
-                      const String &resource_type,
+                      const m2m::String &resource_type,
                       char *path,
                       bool external_blockwise_store = false);
 
@@ -89,8 +89,8 @@ public:
      *        otherwise handled in mbed-client-c.
      * \return M2MResource The resource for managing other client operations.
      */
-    M2MResource* create_static_resource(const String &resource_name,
-                                        const String &resource_type,
+    M2MResource* create_static_resource(const m2m::String &resource_name,
+                                        const m2m::String &resource_type,
                                         M2MResourceInstance::ResourceType type,
                                         const uint8_t *value,
                                         const uint8_t value_length,
@@ -110,8 +110,8 @@ public:
      *        otherwise handled in mbed-client-c.
      * \return M2MResource The resource for managing other client operations.
      */
-    M2MResource* create_dynamic_resource(const String &resource_name,
-                                         const String &resource_type,
+    M2MResource* create_dynamic_resource(const m2m::String &resource_name,
+                                         const m2m::String &resource_type,
                                          M2MResourceInstance::ResourceType type,
                                          bool observable,
                                          bool multiple_instance = false,
@@ -157,8 +157,8 @@ public:
      *        otherwise handled in mbed-client-c.
      * \return M2MResourceInstance The resource instance for managing other client operations.
      */
-    M2MResourceInstance* create_static_resource_instance(const String &resource_name,
-                                                         const String &resource_type,
+    M2MResourceInstance* create_static_resource_instance(const m2m::String &resource_name,
+                                                         const m2m::String &resource_type,
                                                          M2MResourceInstance::ResourceType type,
                                                          const uint8_t *value,
                                                          const uint8_t value_length,
@@ -177,8 +177,8 @@ public:
      *        otherwise handled in mbed-client-c.
      * \return M2MResourceInstance The resource instance for managing other client operations.
      */
-    M2MResourceInstance* create_dynamic_resource_instance(const String &resource_name,
-                                                          const String &resource_type,
+    M2MResourceInstance* create_dynamic_resource_instance(const m2m::String &resource_name,
+                                                          const m2m::String &resource_type,
                                                           M2MResourceInstance::ResourceType type,
                                                           bool observable,
                                                           uint16_t instance_id,
@@ -191,7 +191,7 @@ public:
      * remove_resource(const char*) version instead.
      * \return True if removed, else false.
      */
-    bool remove_resource(const String &name);
+    bool remove_resource(const m2m::String &name);
 
     /**
      * \brief Removes the resource with the given name.
@@ -206,7 +206,7 @@ public:
      * \param instance_id The instance ID of the instance.
      * \return True if removed, else false.
      */
-    bool remove_resource_instance(const String &resource_name,
+    bool remove_resource_instance(const m2m::String &resource_name,
                                           uint16_t instance_id);
 
     /**
@@ -216,7 +216,7 @@ public:
      */
     M2MResource* resource(const uint16_t resource_id) const;
 
-    M2MResource* resource(const String &name) const;
+    M2MResource* resource(const m2m::String &name) const;
 
     M2MResource* resource(const char *resource) const;
 
@@ -239,7 +239,7 @@ public:
      * \param resource The name of the resource.
      * \return Total number of the resources.
      */
-    uint16_t resource_count(const String& resource) const;
+    uint16_t resource_count(const m2m::String& resource) const;
 
     /**
      * \brief Returns the total number of single resource instances.

--- a/mbed-client/mbed-client/m2mresource.h
+++ b/mbed-client/mbed-client/m2mresource.h
@@ -66,9 +66,9 @@ private: // Constructor and destructor are private,
      *        otherwise handled in mbed-client-c.
      */
     M2MResource(M2MObjectInstance &_parent,
-                const String &resource_name,
+                const m2m::String &resource_name,
                 M2MBase::Mode mode,
-                const String &resource_type,
+                const m2m::String &resource_type,
                 M2MBase::DataType type,
                 const uint8_t *value,
                 const uint8_t value_length,
@@ -89,9 +89,9 @@ private: // Constructor and destructor are private,
      *        otherwise handled in mbed-client-c.
      */
     M2MResource(M2MObjectInstance &_parent,
-                const String &resource_name,
+                const m2m::String &resource_name,
                 M2MBase::Mode mode,
-                const String &resource_type,
+                const m2m::String &resource_type,
                 M2MBase::DataType type,
                 bool observable,
                 char *path,
@@ -328,7 +328,7 @@ private:
     M2MExecuteParameter(const char *object_name, const char *resource_name, uint16_t object_instance_id);
 #else
     // This is a deprecated constructor, to be removed on next release.
-    M2MExecuteParameter(const String &object_name, const String &resource_name, uint16_t object_instance_id);
+    M2MExecuteParameter(const m2m::String &object_name, const m2m::String &resource_name, uint16_t object_instance_id);
 #endif
 
 public:
@@ -352,7 +352,7 @@ public:
 #ifdef MEMORY_OPTIMIZED_API
     const char* get_argument_object_name() const;
 #else
-    const String& get_argument_object_name() const;
+    const m2m::String& get_argument_object_name() const;
 #endif
 
     /**
@@ -362,7 +362,7 @@ public:
 #ifdef MEMORY_OPTIMIZED_API
     const char* get_argument_resource_name() const;
 #else
-    const String& get_argument_resource_name() const;
+    const m2m::String& get_argument_resource_name() const;
 #endif
 
     /**
@@ -378,8 +378,8 @@ private:
     const char      *_object_name;
     const char      *_resource_name;
 #else
-    const String    &_object_name;
-    const String    &_resource_name;
+    const m2m::String    &_object_name;
+    const m2m::String    &_resource_name;
 #endif
 
     const uint8_t   *_value;

--- a/mbed-client/mbed-client/m2mresourcebase.h
+++ b/mbed-client/mbed-client/m2mresourcebase.h
@@ -35,7 +35,7 @@ typedef void(*notification_sent_callback_2) (void);
 
 #ifndef DISABLE_BLOCK_MESSAGE
 typedef FP1<void, M2MBlockMessage *> incoming_block_message_callback;
-typedef FP3<void, const String &, uint8_t *&, uint32_t &> outgoing_block_message_callback;
+typedef FP3<void, const m2m::String &, uint8_t *&, uint32_t &> outgoing_block_message_callback;
 #endif
 
 class M2MResource;
@@ -136,9 +136,9 @@ protected: // Constructor and destructor are private
      *        otherwise handled in mbed-client-c.
      */
     M2MResourceBase(
-                        const String &resource_name,
+                        const m2m::String &resource_name,
                         M2MBase::Mode mode,
-                        const String &resource_type,
+                        const m2m::String &resource_type,
                         M2MBase::DataType type,
                         char* path,
                         bool external_blockwise_store,
@@ -158,9 +158,9 @@ protected: // Constructor and destructor are private
      *        otherwise handled in mbed-client-c.
      */
     M2MResourceBase(
-                        const String &resource_name,
+                        const m2m::String &resource_name,
                         M2MBase::Mode mode,
-                        const String &resource_type,
+                        const m2m::String &resource_type,
                         M2MBase::DataType type,
                         const uint8_t *value,
                         const uint8_t value_length,
@@ -335,7 +335,7 @@ public:
      * Get the value as a string object. No encoding/charset conversions
      * are done for the value, just a raw copy.
      */
-    String get_value_string() const;
+    m2m::String get_value_string() const;
 
     /**
      * \brief Converts a value to float and returns it. Note: Conversion

--- a/mbed-client/mbed-client/m2mresourceinstance.h
+++ b/mbed-client/mbed-client/m2mresourceinstance.h
@@ -52,9 +52,9 @@ private: // Constructor and destructor are private
      *        otherwise handled in mbed-client-c.
      */
     M2MResourceInstance(M2MResource &parent,
-                        const String &resource_name,
+                        const m2m::String &resource_name,
                         M2MBase::Mode mode,
-                        const String &resource_type,
+                        const m2m::String &resource_type,
                         M2MBase::DataType type,
                         char* path,
                         bool external_blockwise_store,
@@ -74,9 +74,9 @@ private: // Constructor and destructor are private
      *        otherwise handled in mbed-client-c.
      */
     M2MResourceInstance(M2MResource &parent,
-                        const String &resource_name,
+                        const m2m::String &resource_name,
                         M2MBase::Mode mode,
-                        const String &resource_type,
+                        const m2m::String &resource_type,
                         M2MBase::DataType type,
                         const uint8_t *value,
                         const uint8_t value_length,

--- a/mbed-client/mbed-client/m2msecurity.h
+++ b/mbed-client/mbed-client/m2msecurity.h
@@ -154,7 +154,7 @@ public:
      * \return True if successfully set, else false.
      */
     bool set_resource_value(SecurityResource resource,
-                            const String &value,
+                            const m2m::String &value,
                             uint16_t instance_id);
 
     /**
@@ -191,7 +191,7 @@ public:
      * \param instance_id Instance id of the security instance where resource value should be retrieved.
      * \return The value associated with the resource. If the resource is not valid an empty string is returned.
      */
-    String resource_value_string(SecurityResource resource, uint16_t instance_id) const;
+    m2m::String resource_value_string(SecurityResource resource, uint16_t instance_id) const;
 
     /**
      * \brief Populates the data buffer and returns the size of the buffer.

--- a/source/include/ConnectorClient.h
+++ b/source/include/ConnectorClient.h
@@ -62,12 +62,12 @@ public:
 
 public:
 
-    String                          endpoint_name;
-    String                          account_id;
-    String                          internal_endpoint_name;
+    m2m::String                          endpoint_name;
+    m2m::String                          account_id;
+    m2m::String                          internal_endpoint_name;
     M2MSecurity::SecurityModeType   mode;
 #ifdef MBED_CLOUD_CLIENT_EDGE_EXTENSION
-    String                          lwm2m_server_uri;
+    m2m::String                          lwm2m_server_uri;
 #endif
 };
 


### PR DESCRIPTION
<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[X] I confirm this contribution is my own and I agree to license it with Apache 2.0.
[X] I confirm the moderators may change the PR before merging it in.
[X] I understand the release model prohibits detailed Git history and my contribution will be recorded to the list at the bottom of [CONTRIBUTING.md](CONTRIBUTING.md).


### Summary of changes <!-- Required -->

<!--
    Please provide the following information:

    Description of the the change (what is this fixing / adding / removing?).

    Why the change is needed, add references to issues if this is a fix.

    Avoid too large commits. Each commit should be an atomic, independent change.

    Write good, descriptive Git commit messages.

-->
Attempting to build any application with `mbed-cloud-client` using Mbed-OS version `mbed-os-6.0.0-rc2` would result in compilation errors due to a nascent ambiguity between `m2m::String` and `std::String`.

A sample of the build error output is attached.

[build-errors.log](https://github.com/ARMmbed/mbed-cloud-client/files/4767066/build-errors.log)

This PR fixes the build error by fully-qualifying the `String` type (changed to `m2m::String`) used throughout the mbed-cloud-client library. Perhaps the mbed-cloud-client code should more consistent in putting things in the `m2m` namespace to avoid these kinds of things?

Either way, fully qualifying a type as ambiguous as `String` is always a good idea.
